### PR TITLE
Overhaul FSM

### DIFF
--- a/fsm/fsm.c
+++ b/fsm/fsm.c
@@ -30,9 +30,9 @@ fsm fsm_init(size_t state_count, size_t event_count) {
     (handle)->state_count   = state_count;
     (handle)->event_count   = event_count;
 
-    (handle)->events_async = malloc(sizeof(bool) * (handle)->event_count);
-    (handle)->events_sync  = malloc(sizeof(bool) * (handle)->event_count);
-    (handle)->state_table  = malloc(sizeof(struct state) * (handle)->state_count);
+    (handle)->events_async = (bool *)malloc(sizeof(bool) * (handle)->event_count);
+    (handle)->events_sync  = (bool *)malloc(sizeof(bool) * (handle)->event_count);
+    (handle)->state_table  = (fsm_state *)malloc(sizeof(struct state) * (handle)->state_count);
 
     for (size_t i = 0; i < (handle)->event_count; i++) {
         (handle)->events_async[i] = false;

--- a/fsm/fsm.c
+++ b/fsm/fsm.c
@@ -84,9 +84,8 @@ void fsm_run(fsm handle) {
     for (size_t i = 0; i < handle->event_count; i++) {
         if (handle->events_async[i] != handle->events_sync[i] &&
             handle->state_table[handle->current_state].handler != NULL) {
-            if (handle->state_table[handle->current_state].handler(handle, i) == EVENT_HANDLED) {
-                handle->events_sync[i] = handle->events_async[i];
-            }
+            handle->state_table[handle->current_state].handler(handle, i);
+            handle->events_sync[i] = handle->events_async[i];
         }
     }
 }

--- a/fsm/fsm.h
+++ b/fsm/fsm.h
@@ -15,12 +15,10 @@
 #include <stdbool.h>
 #include <stdlib.h>
 
-typedef enum { EVENT_HANDLED, EVENT_UNKNOWN } event_result;
-
 typedef struct fsm *fsm;
 
 typedef void (*state_function)(fsm);
-typedef event_result (*event_handler)(fsm, uint8_t event);
+typedef void (*event_handler)(fsm, uint8_t event);
 
 typedef struct state {
     event_handler handler;

--- a/fsm/fsm.h
+++ b/fsm/fsm.h
@@ -1,6 +1,6 @@
 /**
- * @file		fsm.h
- * @brief		This file contains the primitives to setup a FSM
+ * @file        fsm.h
+ * @brief		Finite state machine implementation in C
  *
  * @date		Oct 24, 2019
  *
@@ -31,9 +31,10 @@ typedef struct state {
  * 
  * @param state_count Number of states
  * @param event_count Number of events
+ * @param transition_callback Callback function that is called after each state transition
  * @return fsm The initialized FSM handle
  */
-fsm fsm_init(size_t state_count, size_t event_count);
+fsm fsm_init(size_t state_count, size_t event_count, state_function transition_callback);
 
 /**
  * @brief Destroys the FSM
@@ -60,7 +61,8 @@ void fsm_set_state(fsm handle, uint32_t id, fsm_state *state);
 
 /**
  * @brief Executes a state transition
- * @details Runs the exit state of the current state, and runs the entry state of the next state
+ * @details Runs the exit state of the current state, and runs the entry state of the next state. If present the transition callback is executed
+ * @note Use this on event handlers. Avoid using it outside of the FSM. Triggering events is the reccomended action for that use case.
  * 
  * @param handle The FSM instance handle
  * @param state The next state
@@ -71,7 +73,7 @@ void fsm_transition(fsm handle, uint32_t state);
  * @brief Returns the current running state
  * 
  * @param handle The FSM instance handle
- * @return uint32_t The current state
+ * @return The current state
  */
 uint32_t fsm_get_state(fsm handle);
 
@@ -81,7 +83,7 @@ uint32_t fsm_get_state(fsm handle);
  * @param handle The FSM instance handle
  * @param event Event to set
  */
-void fsm_catch_event(fsm handle, uint32_t event);
+void fsm_trigger_event(fsm handle, uint32_t event);
 
 /**
  * @brief Runs the FSM event handlers

--- a/fsm/fsm.h
+++ b/fsm/fsm.h
@@ -12,35 +12,84 @@
 #define FSM_H
 
 #include <inttypes.h>
+#include <stdbool.h>
+#include <stdlib.h>
 
 typedef enum { EVENT_HANDLED, EVENT_UNKNOWN } event_result;
 
-typedef struct fsm fsm;
+typedef struct fsm *fsm;
 
-typedef void (*state_function)(fsm *);
-typedef event_result (*event_handler)(fsm *, uint8_t event);
+typedef void (*state_function)(fsm);
+typedef event_result (*event_handler)(fsm, uint8_t event);
 
-struct state {
+typedef struct state {
     event_handler handler;
-    state_function start;
-    state_function stop;
-};
+    state_function entry;
+    state_function exit;
+} fsm_state;
 
-struct fsm {
-    uint16_t current_state;
+/**
+ * @brief Initializes a FSM instance
+ * 
+ * @param state_count Number of states
+ * @param event_count Number of events
+ * @return fsm The initialized FSM handle
+ */
+fsm fsm_init(size_t state_count, size_t event_count);
 
-    uint32_t events;
+/**
+ * @brief Destroys the FSM
+ * 
+ * @param handle The FSM instance to deinit
+ */
+void fsm_deinit(fsm *handle);
 
-    uint16_t state_count;
-    struct state *state_table;
-};
+/**
+ * @brief Starts the FSM by running the entry function of the initial state
+ * 
+ * @param handle The FSM instance handle
+ */
+void fsm_start(fsm handle);
 
-void fsm_init(fsm *FSM);
-void fsm_start(fsm *FSM);
-void fsm_deinit(fsm *FSM);
-void fsm_transition(fsm *FSM, uint16_t state);
-uint16_t fsm_get_state(fsm *FSM);
-void fsm_catch_event(fsm *FSM, uint32_t event);
-void fsm_run(fsm *FSM);
+/**
+ * @brief Adds a state to the internal state table
+ * 
+ * @param handle The FSM instance handle
+ * @param id ID of the state
+ * @param state FSM state definition
+ */
+void fsm_set_state(fsm handle, uint32_t id, fsm_state *state);
+
+/**
+ * @brief Executes a state transition
+ * @details Runs the exit state of the current state, and runs the entry state of the next state
+ * 
+ * @param handle The FSM instance handle
+ * @param state The next state
+ */
+void fsm_transition(fsm handle, uint32_t state);
+
+/**
+ * @brief Returns the current running state
+ * 
+ * @param handle The FSM instance handle
+ * @return uint32_t The current state
+ */
+uint32_t fsm_get_state(fsm handle);
+
+/**
+ * @brief Sets the internal register for a given event
+ * 
+ * @param handle The FSM instance handle
+ * @param event Event to set
+ */
+void fsm_catch_event(fsm handle, uint32_t event);
+
+/**
+ * @brief Runs the FSM event handlers
+ * 
+ * @param handle The FSM instance handle
+ */
+void fsm_run(fsm handle);
 
 #endif

--- a/fsm/fsm.h
+++ b/fsm/fsm.h
@@ -11,27 +11,36 @@
 #ifndef FSM_H
 #define FSM_H
 
-#include "priority_queue.h"
-
 #include <inttypes.h>
+
+typedef enum { EVENT_HANDLED, EVENT_UNKNOWN } event_result;
 
 typedef struct fsm fsm;
 
-typedef uint16_t (*state_function)(fsm *);
+typedef void (*state_function)(fsm *);
+typedef event_result (*event_handler)(fsm *, uint8_t event);
+
+struct state {
+    event_handler handler;
+    state_function start;
+    state_function stop;
+};
 
 struct fsm {
     uint16_t current_state;
-    uint16_t future_state;
-    uint16_t state_count;
 
-    PQ_QueueTypeDef event_queue;
-    state_function **state_table;
+    uint32_t events;
+
+    uint16_t state_count;
+    struct state *state_table;
 };
 
-void fsm_init(fsm *FSM, uint16_t state_count);
+void fsm_init(fsm *FSM);
+void fsm_start(fsm *FSM);
 void fsm_deinit(fsm *FSM);
+void fsm_transition(fsm *FSM, uint16_t state);
 uint16_t fsm_get_state(fsm *FSM);
-void fsm_handle_event(fsm *FSM, uint16_t state);
+void fsm_catch_event(fsm *FSM, uint32_t event);
 void fsm_run(fsm *FSM);
 
 #endif


### PR DESCRIPTION
This is a radical change in the design of the FSM

## States
Instead of a state matrix, now states are structs that contain pointers to the entry, exit, and event handling functions.
The entry and exit functions are only called once, and the event handling function is only called inside `fsm_run` when a pending event is present.
I'm questioning whether state transitions can be called from within an entry or exit function. It is currently possible, but might not be a good idea. The advantage of doing this is that we can have very simple states that function as transitions in which only the entry function is called. At the end of the entry function, `fsm_transition` calls the exit function of the current state and transitions directly to another state. It sounds like a hack but can't decide if it's a good or bad hack. I'm open to suggestions.

## Events
Events are stored as a bitset in a uint32. This limits the maximum amount of events to 32 items, but makes them a breeze to handle.
The event handler gets called once for each active event. The handler can call `fsm_transition()` directly to execute state transitions. Everyone can trigger events with `fsm_catch_event()`.
Events get reset whether they have been handled or not to avoid starvation.
The event handler has a return enum value that is unused and could probably be removed if no use for it is found.

This is all a work in progress and I'm open to suggestions and changes from those who will need to use it. It currently fits my use case, but might not fit yours atm